### PR TITLE
Print User IP When Anonymous

### DIFF
--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -104,7 +104,7 @@ class Listener {
 		}
         
         // Check if Current User is Guest
-        if ($this->currentUser->getUserIdentifier() === null) {
+        if ($this->currentUser->getUserIdentifier() === '') {
           $requestor = 'Anonymous ' . $_SERVER['REMOTE_ADDR'];
         } else {
           $requestor = $this->currentUser->getUserIdentifier();

--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -102,6 +102,14 @@ class Listener {
 		} else if ($this->request->isUserAgent([IRequest::USER_AGENT_CLIENT_ANDROID, IRequest::USER_AGENT_CLIENT_IOS])) {
 			$client = 'mobile';
 		}
+        
+        // Check if Current User is Guest
+        if ($this->currentUser->getUserIdentifier() === null) {
+          $requestor = 'Anonymous ' . $_SERVER['REMOTE_ADDR'];
+        } else {
+          $requestor = $this->currentUser->getUserIdentifier();
+        }
+        
 		$subjectParams = [[$fileId => $filePath], $this->currentUser->getUserIdentifier(), $client];
 
 		if ($isDir) {

--- a/lib/Activity/Listener.php
+++ b/lib/Activity/Listener.php
@@ -110,7 +110,7 @@ class Listener {
           $requestor = $this->currentUser->getUserIdentifier();
         }
         
-		$subjectParams = [[$fileId => $filePath], $this->currentUser->getUserIdentifier(), $client];
+		$subjectParams = [[$fileId => $filePath], $requestor, $client];
 
 		if ($isDir) {
 			$subject = Provider::SUBJECT_SHARED_FOLDER_DOWNLOADED;


### PR DESCRIPTION
Should display the user IP when the user is not a registered user of the Nextcloud instance.  This will at least give basic information of whom the user was and if the file is being distributed beyond its original scopre.